### PR TITLE
Add unit test for themes with custom headers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,6 +71,16 @@ module.exports = function(grunt) {
 					type: 'wp-plugin'
 				}
 			},
+			theme_headers: {
+				options: {
+					cwd: 'tmp/theme-headers',
+					processPot: function( pot, options ) {
+						pot.headers['language-team'] = 'Team Name <team@example.com>';
+						return pot;
+					},
+					type: 'wp-theme'
+				}
+			},
 			ignore_headers: {
 				options: {
 					cwd: 'tmp/plugin-headers',

--- a/test/fixtures/theme-headers/style.css
+++ b/test/fixtures/theme-headers/style.css
@@ -1,0 +1,3 @@
+/**
+ * Theme Name: Example Theme
+ */

--- a/test/makepot_test.js
+++ b/test/makepot_test.js
@@ -61,6 +61,17 @@ exports.makepot = {
 		test.done();
 	},
 
+	theme_headers: function( test ) {
+		test.expect( 2 );
+		var potFile = 'tmp/theme-headers/theme-headers.pot';
+		test.ok( grunt.file.exists( potFile ), 'should compile a pot file in the main theme directory' );
+
+		var pot = gettext.po.parse( grunt.file.read( potFile ) );
+		var teamHeader = 'Team Name <team@example.com>';
+		test.equal( teamHeader, pot.headers['language-team'], 'the language team header should match the value set in the processPot callback.' );
+		test.done();
+	},
+
 	ignore_headers: function( test ) {
 		test.expect( 1 );
 		var potFile = 'tmp/plugin-headers/override.pot';


### PR DESCRIPTION
Similar to the unit test for plugins with custom headers.

I've got an issue where the processPot callback isn't being called for a theme I'm trying to generate a .pot for. The .pot uses the default headers. Wrote this unit test to try and debug an issue, but it passes fine, so I'm not sure what the problem is with my project.
