### PR TITLE
Add checktextdomain task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,24 @@
 
 'use strict';
 
+//For convenience store keywards in global
+var keywords = [
+	'__:1,2d',
+	'_e:1,2d',
+	'_x:1,2c,3d',
+	'esc_html__:1,2d',
+	'esc_html_e:1,2d',
+	'esc_html_x:1,2c,3d',
+	'esc_attr__:1,2d', 
+	'esc_attr_e:1,2d', 
+	'esc_attr_x:1,2c,3d', 
+	'_ex:1,2c,3d',
+	'_n:1,2,4d', 
+	'_nx:1,2,4c,5d',
+	'_n_noop:1,2,3d',
+	'_nx_noop:1,2,3c,4d'
+	];
+
 module.exports = function(grunt) {
 
 	grunt.loadTasks( 'tasks' );
@@ -34,8 +52,9 @@ module.exports = function(grunt) {
 			tests: ['tmp']
 		},
 
+		// Copy test files
 		copy: {
-			tests: {
+			tests: { // Copies tests/fixtures/foobar/foobar.ext to tmp/foobar/foobar.ext
 				files: [
 					{
 						expand: true,
@@ -112,6 +131,79 @@ module.exports = function(grunt) {
 			}
 		},
 
+		// Configuration to be run (and then tested).
+		checktextdomain: {
+			correctDomain: {
+				options:{
+					textdomain: 'my-domain',
+					createReportFile: 'tmp/check-textdomain/correct-domain.json',
+					keywords: keywords
+				},
+				files: [{
+					src: ['tmp/check-textdomain/correct-domain.php'],
+					expand: true,
+				}],
+			},
+			missing_domain: {
+				options:{
+					textdomain: 'my-domain',
+					createReportFile: 'tmp/check-textdomain/missing-domain.json',
+					keywords: keywords
+				},
+				files: [{
+					src: ['tmp/check-textdomain/missing-domain.php'],
+					expand: true,
+				}],
+			},
+			missing_domain_ignore_missing: {
+				options:{
+					textdomain: 'my-domain',
+					reportMissing: false,
+					createReportFile: 'tmp/check-textdomain/missing-domain-ignore-missing.json',
+					keywords: keywords
+				},
+				files: [{
+					src: ['tmp/check-textdomain/missing-domain.php'],
+					expand: true,
+				}],
+			},
+			incorrect_domain_autocomplete: {
+				options:{
+					textdomain: 'my-domain',
+					correctDomain: true,
+					createReportFile: 'tmp/check-textdomain/incorrect-domain-autocomplete.json',
+					keywords: keywords
+				},
+				files: [{
+					src: ['tmp/check-textdomain/incorrect-domain-autocorrect.php'],
+					expand: true,
+				}],
+			},
+			variable_domain_autocomplete: {
+				options:{
+					textdomain: 'my-domain',
+					correctDomain: true,
+					createReportFile: 'tmp/check-textdomain/variable-domain-autocorrect.json',
+					keywords: keywords
+				},
+				files: [{
+					src: ['tmp/check-textdomain/variable-domain-autocorrect.php'],
+					expand: true,
+				}],
+			},
+			plurals: {
+				options:{
+					textdomain: 'my-domain',
+					createReportFile: 'tmp/check-textdomain/plurals.json',
+					keywords: keywords
+				},
+				files: [{
+					src: ['tmp/check-textdomain/plurals.php'],
+					expand: true,
+				}],
+			}
+		},
+
 		// Unit tests.
 		nodeunit: {
 			tests: ['test/*_test.js'],
@@ -124,6 +216,6 @@ module.exports = function(grunt) {
 
 	// Whenever the "test" task is run, first clean the "tmp" dir,
 	// copy the "fixtures", then run this plugin's task(s), then test the result.
-	grunt.registerTask( 'test', ['clean', 'copy', 'makepot', 'nodeunit']);
+	grunt.registerTask( 'test', ['clean', 'copy', 'makepot', 'checktextdomain', 'nodeunit']);
 
 };

--- a/README.md
+++ b/README.md
@@ -244,6 +244,150 @@ grunt.initConfig({
 
 This task supports the file mapping format Grunt supports. Please read [Globbing patterns](http://gruntjs.com/configuring-tasks#globbing-patterns) and [Building the files object dynamically](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically) for additional details.
 
+## The "checktextdomain" task
+
+### Important: Before you start
+
+For the task to run you need to specify:
+
+1. **Text domain(s)** - a string or array of valid text domain
+2. **Keywords** - gettext functions, along with a specification indicating where to look for the text domain
+
+
+#### Keyword specifications
+This task extends the original [keyword specification](http://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html) to indicate where to look for the text domain. The default specification is of the form
+
+``` 
+    [function name]:[argument-specifier],[argument-specifier],...
+```
+where an argument specificier is of the form
+
+ - `[number]` - indicating that this argument is a translatable string
+ - `[number]c` - indicating that this argument is a context specifier
+
+
+For example:
+
+ - `gettext` - the translated string is the first argument of `gettext()`
+ - `ngettext:1,2` -  the translated strings are arguments 1 and 2 of of `ngettext()`
+ - `pgettext:1c,2` -  argument 1 is a context specifier and the translated string is argument 2 of `pgettext()`
+
+
+This task requires an additional argument specifier (in fact this is the only required one): `[number]d` - indicating that the argument is a domain specifier. For example:
+
+ - `__:1,2d` - the translated string is the first argument of `__()` and the domain is the second argument
+ - `_n:1,2,4d` -  the translated strings are arguments 1 and 2 of `_n()` and the fourth is the domain specifier.
+ - `_nx:1,2,3c,5d` -  the translated strings are arguments 1 and 2 of `_nx()`, the third is a context specifier and the fifth is the domain specifier.
+
+
+#### Example keyword specifications (WordPress)
+
+```
+keywords: [
+    '__:1,2d',
+    '_e:1,2d',
+    '_x:1,2c,3d',
+    'esc_html__:1,2d',
+    'esc_html_e:1,2d',
+    'esc_html_x:1,2c,3d',
+    'esc_attr__:1,2d', 
+    'esc_attr_e:1,2d', 
+    'esc_attr_x:1,2c,3d', 
+    '_ex:1,2c,3d',
+    '_n:1,2,4d', 
+    '_nx:1,2,4c,5d',
+    '_n_noop:1,2,3d',
+    '_nx_noop:1,2,3c,4d'
+];
+```
+
+### Overview
+In your project's Gruntfile, add a section named `checktextdomain` to the data object passed into `grunt.initConfig()`.
+
+```js
+grunt.initConfig({
+    checktextdomain: {
+        options: {
+            // Task-specific options go here.
+        },
+        files: {
+        // Files to target go here
+        },
+    },
+});
+```
+
+### Options
+
+#### textdomain
+Type: `String`|`Array`
+
+Must be provided. A text domain (or an array of text domains) indicating the domains to check against.
+
+#### keywords
+Type: `Array`
+
+An array of keyword specifications to look for. See above section for details & examples.
+
+#### reportMissing
+Type: `Bool`
+Default value: `true`
+
+Whether to report use of keywords without a domain being passed.
+
+#### reportVariableDomain
+Type: `Bool`
+Default value: `true`
+
+Whether to report use of keywords with a variable being used as the domain.
+
+#### correctDomain
+Type: `Bool`
+Default value: `false`
+
+Whether to automatically correct incorrect domains. Please note that this does **not** add in missing domains, and can **only** be used when one text domain is supplied. This will also correct instances where a variable, rather than string is used as a text doman, **unless** you set `reportVariableDomain` to `false`.
+
+#### createReportFile
+Type: `Bool`
+Default value: `false`
+
+Create a hidden `.[target].json` file with reported errors.
+
+### Usage Examples
+
+This is a typical set-up for WordPress development. The only thing specific to WordPress here is the keywords list.
+
+```js
+grunt.initConfig({
+    checktextdomain: {
+        standard{
+            options:{
+                textdomain: 'my-domain', //Specify allowed domain(s)
+                keywords: [ //List keyword specifications
+                    '__:1,2d',
+                    '_e:1,2d',
+                    '_x:1,2c,3d',
+                    'esc_html__:1,2d',
+                    'esc_html_e:1,2d',
+                    'esc_html_x:1,2c,3d',
+                    'esc_attr__:1,2d', 
+                    'esc_attr_e:1,2d', 
+                    'esc_attr_x:1,2c,3d', 
+                    '_ex:1,2c,3d',
+                    '_n:1,2,4d', 
+                    '_nx:1,2,4c,5d',
+                    '_n_noop:1,2,3d',
+                    '_nx_noop:1,2,3c,4d'
+                ]
+            },
+            files: [{
+                src: ['**/*.php'], //all php 
+                expand: true,
+            }],
+        }
+    }
+});
+```
 
 ## Local Config
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   },
   "dependencies": {
     "async": "~0.2.10",
+    "chalk": "~0.5.1",
     "gettext-parser": "~0.2.0",
     "grunt": "~0.4.2",
+    "text-table": "~0.2.0",
     "underscore": "~1.5.2",
     "underscore.string": "~2.3.3"
   },

--- a/tasks/check-textdomain.js
+++ b/tasks/check-textdomain.js
@@ -1,0 +1,983 @@
+/*
+ * grunt-wp-i18n
+ * https://github.com/blazersix/grunt-wp-i18n
+ *
+ * Copyright (c) 2014 Blazer Six, Inc.
+ * Licensed under the MIT license.
+ *
+ * Based on original work:
+ * grunt-checktextdomain
+ * https://github.com/stephenharris/grunt-checktextdomain
+ *
+ * Copyright (c) 2013 Stephen Harris
+ * Licensed under the MIT license.
+ */
+/* jshint -W099 */
+/* jshint -W030 */
+/* jshint -W084 */
+'use strict';
+var chalk = require('chalk');
+var table = require('text-table');
+module.exports = function(grunt) {
+
+  // Please see the Grunt documentation for more information regarding task
+  // creation: http://gruntjs.com/creating-tasks
+
+grunt.registerMultiTask('checktextdomain', 'Checks gettext function calls for missing or incorrect text domain.', function() {
+	// Merge task-specific and/or target-specific options with these defaults.
+	var options = this.options({
+		keywords: false,
+		textdomain: false,
+		reportMissing: true,
+		reportVariableDomain: true,
+		correctDomain: false,
+		createReportFile: false,
+	});
+	
+	grunt.verbose.writeflags( options );
+
+	if( options.textdomain === false ){
+		grunt.fail.warn("Text domain not provided.");
+	}
+	
+	//Cast textdomain as an array to support multiple text domains
+	options.textdomain = ( options.textdomain instanceof Array ) ? options.textdomain : [options.textdomain];
+	
+	//correctDomain can only be used if one domain is specified:
+	options.correctDomain = options.correctDomain && ( options.textdomain.length === 1 ); 
+
+	if( options.keywords === false ){
+		grunt.fail.warn("No keywords specified.");
+	}
+
+	//Init the variables
+	var errors = [];
+	var functions = []; //Array of gettext functions 
+	var func_domain = {}; //Map of gettext function => ordinal number of domain argument
+	var patt = new RegExp("([0-9]+)d", "i");	//Check for domain identifier in keyword specification
+
+	//Parse keywords for gettext function names and ordinal number of domain argument
+	options.keywords.forEach( function(keyword) {
+
+		//parts[0] is keyword name, e.g. __ or _x
+		var parts = keyword.split(':');
+		var name = parts[0];
+		var argument = 0;
+
+		//keyword argument identifiers
+		if( parts.length > 1 ){
+			var args = parts[1];
+			var arg_parts = args.split(',');
+			
+			for( var j=0; j < arg_parts.length; j++ ){
+
+				//check for domain identifier
+				if( patt.test(arg_parts[j]) ){
+					argument = parseInt( patt.exec( arg_parts[j] ), 10 );
+					break;
+				}
+			}
+
+			//No domain identifier found, assume it is #ags + 1
+			argument = argument ? argument : arg_parts.length + 1;
+			
+		//keyword has no argument identifiers -- assume text domain is 2nd argument
+		}else{
+			argument = 2;
+		}
+
+		func_domain[name] = argument;
+		functions.push( name );
+	});
+
+	grunt.verbose.writeflags(func_domain, 'Keywords:');
+
+
+	var all_errors = {};
+	var error_num = 0;
+	
+	// Iterate over all specified file groups.
+	this.files.forEach(function(f) {
+
+		var modified_content = "";
+		
+		//Read file, if it exists
+		var filepath = f.src.join(options.cwd || '', f.src);
+		if ( !grunt.file.exists(filepath ) ) {
+			grunt.log.warn('Source file "' + filepath + '" not found.');
+			return;
+		}
+	
+		//Get tokens
+		var tokens = checktextdomain.token_get_all( grunt.file.read( filepath ) );
+	
+		//Init gettext_func - the current gettext function being inspected
+		var gettext_func = {
+			name: false, //The name of the gettext function
+			line: false, //The line it occurs on
+			domain: false, //The domain used with it (false if not found)
+			argument: 0, //Ordinal argument number we are currently in
+		};
+
+		var parens_balance = 0; //Used to track parenthesis
+
+		for( var i=0; i<tokens.length; i++ ){
+
+			var token = tokens[i][0], text = tokens[i][1], line = tokens[i][2];
+			
+			var content = ( 'undefined' !== typeof tokens[i][1] ? tokens[i][1] : tokens[i][0] );
+			
+			//Look for T_STRING (function call )
+			if( token === 306 && functions.indexOf( text ) > -1 ){
+
+				gettext_func ={
+					name: text,
+					line: line,
+					domain: false,
+					argument: 0,
+				};
+	
+				parens_balance = 0;
+				
+			//Check for T_CONSTANT_ENCAPSED_STRING - and that we are in the text-domain argument
+			}else if( token === 314 && gettext_func.line && func_domain[gettext_func.name] === gettext_func.argument ){
+	
+				if( gettext_func.argument > 0 ){
+					gettext_func.domain = text.substr(1,text.length -2);//get rid of quotes from beginning & end
+					
+					//Correct content
+					if( options.correctDomain && gettext_func.domain !== options.textdomain[0] ){
+						content = "'"+options.textdomain[0]+"'";
+					}
+				}
+				
+			//Check for variable - and that we are in the text-domain argument
+			}else if( token === 308 && gettext_func.line && func_domain[gettext_func.name] === gettext_func.argument ){
+	
+				if( gettext_func.argument > 0 ){
+					gettext_func.domain = -1; //We don't know what the domain is )its a variable).
+					
+					//Corect content
+					if( options.reportVariableDomain && options.correctDomain ){
+						content = "'"+options.textdomain[0]+"'";
+					}
+				}
+				
+			//Check for comma seperating arguments. Only interested in 'top level' where parens_balance == 1
+			}else if ( token === ',' && parens_balance === 1 && gettext_func.line ){
+				gettext_func.argument++;
+	
+			//If we are an opening bracket, increment parens_balance
+			}else if( '(' === token && gettext_func.line  ){
+				
+				//If in gettext function and found opening parenthesis, we are at first argument
+				if( gettext_func.argument === 0 ){
+					gettext_func.argument = 1;
+				}
+				
+				parens_balance++;
+	
+			//If in gettext function and found closing parenthesis,
+			}else if( ')' === token && gettext_func.line ){
+				parens_balance--;
+
+				//If parenthesis match we have parsed all the function's arguments. Time to tally.
+				if ( gettext_func.line && 0 === parens_balance ) {
+	
+					var error_type = false;
+					
+					if( ( options.reportVariableDomain && gettext_func.domain === -1 ) ){
+						error_type = 'variable-domain'; 
+							
+					}else if( options.reportMissing && !gettext_func.domain ){ 
+						error_type = 'missing-domain';
+						
+					}else if( gettext_func.domain && gettext_func.domain !== -1 && options.textdomain.indexOf( gettext_func.domain ) === -1 ) {
+						error_type = 'incorrect-domain';
+						
+					}
+					
+					if( error_type ){
+						errors.push( gettext_func );
+					}
+	
+					//Reset gettext_func
+					gettext_func = {
+						name: false,
+						line: false,
+						domain: false,
+						argument: 0,
+					};
+				}
+				
+			}
+			
+			modified_content += content;
+
+		}
+		
+		//Output errors
+		if( errors.length > 0 ){
+
+			console.log( "\n" + chalk.bold.underline(f.src));
+
+			var rows = [],error_line,func,message;
+			for( i = 0; i < errors.length; i++ ){
+
+				error_line = chalk.yellow(grunt.template.process('[L<%= line %>]', {data: errors[i]}) );
+				func = chalk.cyan(errors[i].name);
+			
+				if(  !errors[i].domain ) {
+					message =  chalk.red( 'Missing text domain' );
+				
+				}else if(  errors[i].domain === -1 ) {
+					message =  chalk.red( 'Variable used in domain argument' );
+					
+				}else{
+					message =  chalk.red( grunt.template.process('Incorrect text domain used ("<%= domain %>")', {data: errors[i]}) );
+				}
+			
+				rows.push( [ error_line, func, message ] );
+				error_num++;
+			}
+			
+			console.log( table(rows) );
+			
+			if( options.correctDomain ){
+				grunt.file.write( filepath, modified_content );
+				console.log( chalk.bold( filepath + ' corrected.' ) );
+			}
+		}
+		
+		all_errors[filepath] = errors;
+		
+		//Reset errors
+		errors = [];
+    });
+	
+	
+	if ( error_num > 0) {
+		console.log( "\n" + chalk.red.bold('✖ ' + error_num + ' problem' + (error_num === 1 ? '' : 's')) );
+	} else {
+		console.log( "\n" + chalk.green.bold('✔ No problems') +  "\n" );
+	}
+	
+	if ( typeof options.createReportFile === 'string' ){
+        grunt.file.write( options.createReportFile, JSON.stringify( all_errors ) );
+    } else if ( options.createReportFile ){
+		grunt.file.write( '.' + this.target + '.json', JSON.stringify( all_errors ) );
+	}
+
+  });
+
+var checktextdomain = {};
+checktextdomain.token_get_all = function (source) {
+	// Split given source into PHP tokens
+	// + original by: Marco Marchiò
+	// + improved by: Brett Zamir (http://brett-zamir.me)
+	// - depends on: token_name
+	// % note 1: Token numbers depend on the PHP version
+	// % note 2: token_name is only necessary for a non-standard php.js-specific use of this function;
+	// % note 2: if you define an object on this.php_js.phpParser (where "this" is the scope of the
+	// % note 2: token_get_all function (either a namespaced php.js object or the window object)),
+	// % note 2: this function will call that object's methods if they have the same names as the tokens,
+	// % note 2: passing them the string, line number, and token number (in that order)
+	// * example 1: token_get_all('/'+'* comment *'+'/');
+	// * returns 1: [[310, '/* comment */', 1]]
+
+	// Token to number conversion
+    var num,
+        nextch,
+        word,
+        ch,
+        sym,
+        ASCII,
+        i = 0,
+        that = this,
+        length = source.length,
+        //Regexp to check if the characters that follow a word are valid as heredoc end declaration
+        heredocEndFollowing = /^;?\r?\n/,
+        tokens = {
+            T_REQUIRE_ONCE: 261,
+            T_REQUIRE: 260,
+            T_EVAL: 259,
+            T_INCLUDE_ONCE: 258,
+            T_INCLUDE: 257,
+            T_LOGICAL_OR: 262,
+            T_LOGICAL_XOR: 263,
+            T_LOGICAL_AND: 264,
+            T_PRINT: 265,
+            T_SR_EQUAL: 276,
+            T_SL_EQUAL: 275,
+            T_XOR_EQUAL: 274,
+            T_OR_EQUAL: 273,
+            T_AND_EQUAL: 272,
+            T_MOD_EQUAL: 271,
+            T_CONCAT_EQUAL: 270,
+            T_DIV_EQUAL: 269,
+            T_MUL_EQUAL: 268,
+            T_MINUS_EQUAL: 267,
+            T_PLUS_EQUAL: 266,
+            T_BOOLEAN_OR: 277,
+            T_BOOLEAN_AND: 278,
+            T_IS_NOT_IDENTICAL: 282,
+            T_IS_IDENTICAL: 281,
+            T_IS_NOT_EQUAL: 280,
+            T_IS_EQUAL: 279,
+            T_IS_GREATER_OR_EQUAL: 284,
+            T_IS_SMALLER_OR_EQUAL: 283,
+            T_SR: 286,
+            T_SL: 285,
+            T_INSTANCEOF: 287,
+            T_UNSET_CAST: 296,
+            T_BOOL_CAST: 295,
+            T_OBJECT_CAST: 294,
+            T_ARRAY_CAST: 293,
+            T_STRING_CAST: 292,
+            T_DOUBLE_CAST: 291,
+            T_INT_CAST: 290,
+            T_DEC: 289,
+            T_INC: 288,
+            T_CLONE: 298,
+            T_NEW: 297,
+            T_EXIT: 299,
+            T_IF: 300,
+            T_ELSEIF: 301,
+            T_ELSE: 302,
+            T_ENDIF: 303,
+            T_LNUMBER: 304,
+            T_DNUMBER: 305,
+            T_STRING: 306,
+            T_STRING_VARNAME: 307,
+            T_VARIABLE: 308,
+            T_NUM_STRING: 309,
+            T_INLINE_HTML: 310,
+            T_CHARACTER: 311,
+            T_BAD_CHARACTER: 312,
+            T_ENCAPSED_AND_WHITESPACE: 313,
+            T_CONSTANT_ENCAPSED_STRING: 314,
+            T_ECHO: 315,
+            T_DO: 316,
+            T_WHILE: 317,
+            T_ENDWHILE: 318,
+            T_FOR: 319,
+            T_ENDFOR: 320,
+            T_FOREACH: 321,
+            T_ENDFOREACH: 322,
+            T_DECLARE: 323,
+            T_ENDDECLARE: 324,
+            T_AS: 325,
+            T_SWITCH: 326,
+            T_ENDSWITCH: 327,
+            T_CASE: 328,
+            T_DEFAULT: 329,
+            T_BREAK: 330,
+            T_CONTINUE: 331,
+            T_GOTO: 332,
+            T_FUNCTION: 333,
+            T_CONST: 334,
+            T_RETURN: 335,
+            T_TRY: 336,
+            T_CATCH: 337,
+            T_THROW: 338,
+            T_USE: 339,
+            T_GLOBAL: 340,
+            T_PUBLIC: 346,
+            T_PROTECTED: 345,
+            T_PRIVATE: 344,
+            T_FINAL: 343,
+            T_ABSTRACT: 342,
+            T_STATIC: 341,
+            T_VAR: 347,
+            T_UNSET: 348,
+            T_ISSET: 349,
+            T_EMPTY: 350,
+            T_HALT_COMPILER: 351,
+            T_CLASS: 352,
+            T_INTERFACE: 353,
+            T_EXTENDS: 354,
+            T_IMPLEMENTS: 355,
+            T_OBJECT_OPERATOR: 356,
+            T_DOUBLE_ARROW: 357,
+            T_LIST: 358,
+            T_ARRAY: 359,
+            T_CLASS_C: 360,
+            T_METHOD_C: 361,
+            T_FUNC_C: 362,
+            T_LINE: 363,
+            T_FILE: 364,
+            T_COMMENT: 365,
+            T_DOC_COMMENT: 366,
+            T_OPEN_TAG: 367,
+            T_OPEN_TAG_WITH_ECHO: 368,
+            T_CLOSE_TAG: 369,
+            T_WHITESPACE: 370,
+            T_START_HEREDOC: 371,
+            T_END_HEREDOC: 372,
+            T_DOLLAR_OPEN_CURLY_BRACES: 373,
+            T_CURLY_OPEN: 374,
+            T_PAAMAYIM_NEKUDOTAYIM: 375,
+            T_NAMESPACE: 376,
+            T_NS_C: 377,
+            T_DIR: 378,
+            T_NS_SEPARATOR: 379
+        },
+        //Keywords tokens
+        keywordsToken = {
+            "abstract": tokens.T_ABSTRACT,
+            "array": tokens.T_ARRAY,
+            "as": tokens.T_AS,
+            "break": tokens.T_BREAK,
+            "case": tokens.T_CASE,
+            "catch": tokens.T_CATCH,
+            "class": tokens.T_CLASS,
+            "__CLASS__": tokens.T_CLASS_C,
+            "clone": tokens.T_CLONE,
+            "const": tokens.T_CONST,
+            "continue": tokens.T_CONTINUE,
+            "declare": tokens.T_DECLARE,
+            "default": tokens.T_DEFAULT,
+            "__DIR__": tokens.T_DIR,
+            "die": tokens.T_EXIT,
+            "do": tokens.T_DO,
+            "echo": tokens.T_ECHO,
+            "else": tokens.T_ELSE,
+            "elseif": tokens.T_ELSEIF,
+            "empty": tokens.T_EMPTY,
+            "enddeclare": tokens.T_ENDDECLARE,
+            "endfor": tokens.T_ENDFOR,
+            "endforeach": tokens.T_ENDFOREACH,
+            "endif": tokens.T_ENDIF,
+            "endswitch": tokens.T_ENDSWITCH,
+            "endwhile": tokens.T_ENDWHILE,
+            "eval": tokens.T_EVAL,
+            "exit": tokens.T_EXIT,
+            "extends": tokens.T_EXTENDS,
+            "__FILE__": tokens.T_FILE,
+            "final": tokens.T_FINAL,
+            "for": tokens.T_FOR,
+            "foreach": tokens.T_FOREACH,
+            "function": tokens.T_FUNCTION,
+            "__FUNCTION__": tokens.T_FUNC_C,
+            "global": tokens.T_GLOBAL,
+            "goto": tokens.T_GOTO,
+            "__halt_compiler": tokens.T_HALT_COMPILER,
+            "if": tokens.T_IF,
+            "implements": tokens.T_IMPLEMENTS,
+            "include": tokens.T_INCLUDE,
+            "include_once": tokens.T_INCLUDE_ONCE,
+            "instanceof": tokens.T_INSTANCEOF,
+            "interface": tokens.T_INTERFACE,
+            "isset": tokens.T_ISSET,
+            "__LINE__": tokens.T_LINE,
+            "list": tokens.T_LIST,
+            "and": tokens.T_LOGICAL_AND,
+            "or": tokens.T_LOGICAL_OR,
+            "xor": tokens.T_LOGICAL_XOR,
+            "__METHOD__": tokens.T_METHOD_C,
+            "namespace": tokens.T_NAMESPACE,
+            "__NAMESPACE__": tokens.T_NS_C,
+            "new": tokens.T_NEW,
+            "print": tokens.T_PRINT,
+            "private": tokens.T_PRIVATE,
+            "public": tokens.T_PUBLIC,
+            "protected": tokens.T_PROTECTED,
+            "require": tokens.T_REQUIRE,
+            "require_once": tokens.T_REQUIRE_ONCE,
+            "return": tokens.T_RETURN,
+            "static": tokens.T_STATIC,
+            "switch": tokens.T_SWITCH,
+            "throw": tokens.T_THROW,
+            "try": tokens.T_TRY,
+            "unset": tokens.T_UNSET,
+            "use": tokens.T_USE,
+            "var": tokens.T_VAR,
+            "while": tokens.T_WHILE
+        },
+        //Type casting tokens
+        typeCasting = {
+            "array": tokens.T_ARRAY_CAST,
+            "bool": tokens.T_BOOL_CAST,
+            "boolean": tokens.T_BOOL_CAST,
+            "real": tokens.T_DOUBLE_CAST,
+            "double": tokens.T_DOUBLE_CAST,
+            "float": tokens.T_DOUBLE_CAST,
+            "int": tokens.T_INT_CAST,
+            "integer": tokens.T_INT_CAST,
+            "object": tokens.T_OBJECT_CAST,
+            "string": tokens.T_STRING_CAST,
+            "unset": tokens.T_UNSET_CAST,
+            "binary": tokens.T_STRING_CAST
+        },
+        //Symbols tokens with 2 characters
+        symbols2chars = {
+            "&=": tokens.T_AND_EQUAL,
+            "&&": tokens.T_BOOLEAN_AND,
+            "||": tokens.T_BOOLEAN_OR,
+            "?>": tokens.T_CLOSE_TAG,
+            "%>": tokens.T_CLOSE_TAG,
+            ".=": tokens.T_CONCAT_EQUAL,
+            "--": tokens.T_DEC,
+            "/=": tokens.T_DIV_EQUAL,
+            "=>": tokens.T_DOUBLE_ARROW,
+            "::": tokens.T_PAAMAYIM_NEKUDOTAYIM,
+            "++": tokens.T_INC,
+            "==": tokens.T_IS_EQUAL,
+            ">=": tokens.T_IS_GREATER_OR_EQUAL,
+            "!=": tokens.T_IS_NOT_EQUAL,
+            "<>": tokens.T_IS_NOT_EQUAL,
+            "<=": tokens.T_IS_SMALLER_OR_EQUAL,
+            "-=": tokens.T_MINUS_EQUAL,
+            "%=": tokens.T_MOD_EQUAL,
+            "*=": tokens.T_MUL_EQUAL,
+            "->": tokens.T_OBJECT_OPERATOR,
+            "|=": tokens.T_OR_EQUAL,
+            "+=": tokens.T_PLUS_EQUAL,
+            "<<": tokens.T_SL,
+            ">>": tokens.T_SR,
+            "^=": tokens.T_XOR_EQUAL,
+            "<?": tokens.T_OPEN_TAG
+        },
+        //Symbols tokens with 3 characters
+        symbols3chars = {
+            "===": tokens.T_IS_IDENTICAL,
+            "!==": tokens.T_IS_NOT_IDENTICAL,
+            "<<=": tokens.T_SL_EQUAL,
+            ">>=": tokens.T_SR_EQUAL,
+            "<?=": tokens.T_OPEN_TAG_WITH_ECHO,
+            "<%=": tokens.T_OPEN_TAG_WITH_ECHO
+        },
+        //Buffer tokens
+        bufferTokens = {
+            "html": tokens.T_INLINE_HTML,
+            "inlineComment": tokens.T_COMMENT,
+            "comment": tokens.T_COMMENT,
+            "docComment": tokens.T_DOC_COMMENT,
+            "singleQuote": tokens.T_CONSTANT_ENCAPSED_STRING,
+            "doubleQuotes": tokens.T_CONSTANT_ENCAPSED_STRING,
+            "nowdoc": tokens.T_ENCAPSED_AND_WHITESPACE,
+            "heredoc": tokens.T_ENCAPSED_AND_WHITESPACE
+        },
+        //Characters that are emitted as tokens without a code
+        singleTokenChars = ";(){}[],~@`=+/-*.$|^&<>%!?:\"'\\",
+        //Buffer type. Start an html buffer immediatelly.
+        bufferType = "html",
+        //Buffer content
+        buffer = "",
+        //Last emitted token
+        lastToken,
+        //Results array
+        ret = [],
+        //Word that started the heredoc or nowdoc buffer
+        heredocWord,
+        //Line number
+        line = 1,
+        //Line at which the buffer begins
+        lineBuffer = 1,
+        //Flag that indicates if the current double quoted string has been splitted
+        split,
+        //This variable will store the previous buffer type of the tokenizer before parsing a
+        //complex variable syntax
+        complexVarPrevBuffer,
+        //Number of open brackets inside a complex variable syntax
+        openBrackets,
+        //Function to emit tokens
+        emitToken = function (token, code, preventBuffer, l) {
+            if (!preventBuffer && bufferType) {
+                buffer += token;
+                lastToken = null;
+            } else {
+                lastToken = code || token;
+                ret.push(code ? [code, token, l || line] : token);
+            }
+        },
+        //Function to emit and close the current buffer
+        emitBuffer = function () {
+            buffer && emitToken(buffer, bufferTokens[bufferType], true, lineBuffer);
+            buffer = "";
+            bufferType = null;
+        },
+        //Function to check if the token at the current index is escaped
+        isEscaped = function (s) {
+            var escaped = false,
+                c = (s || i) - 1;
+            for (; c >= 0; c--) {
+                if (source.charAt(c) !== "\\") {
+                    break;
+                }
+                escaped = !escaped;
+            }
+            return escaped;
+        },
+        //Returns the number of line feed characters in the given string
+        countNewLines = function (str) {
+            var i = 0;
+            str.replace(/\n/g, function () {
+                i++;
+            });
+            return i;
+        },
+        //Get the part of source that is between the current index and the index of the limit character
+        getBufferAndEmit = function (start, type, limit, canBeEscaped) {
+            /*23456*/
+            var startL = start.length,
+                startPos = i + startL,
+                pos = source.indexOf(limit, startPos);
+            lineBuffer = line;
+            if (canBeEscaped) {
+                while (pos !== -1 && isEscaped(pos)) {
+                    pos = source.indexOf(limit, pos + 1);
+                }
+            }
+            bufferType = type;
+            if (pos === -1) {
+                buffer = start + source.substr(startPos);
+            } else {
+                buffer = start + source.substr(startPos, pos - startPos) + limit;
+            }
+            line += countNewLines(buffer);
+            emitBuffer();
+            
+        	//If limit is not found, set i to the position of the end of the buffered characters
+            if(pos === -1){
+            	i = i + buffer.length;
+            }else{
+            	i = pos + limit.length - 1;
+            }
+        },
+        //This function is used to split a double quoted string or a heredoc buffer after a variable
+        //has been found inside it
+        splitString = function () {
+            //Don't emit empty buffers
+            if (!buffer) {
+                return;
+            }
+            //If the buffer is a double quoted string and it has not yet been splitted, emit the double
+            //quotes as a token without an associated code
+            if (bufferType === "doubleQuotes" && !split) {
+                split = true;
+                emitToken('"', null, true);
+                buffer = buffer.substr(1);
+            }
+            buffer && emitToken(buffer, tokens.T_ENCAPSED_AND_WHITESPACE, true, lineBuffer);
+            buffer = "";
+            lineBuffer = line;
+        },
+        //Checks if the given ASCII identifies a whitespace
+        isWhitespace = function (ASCII) {
+            return ASCII === 9 || ASCII === 10 || ASCII === 13 || ASCII === 32;
+        },
+        //Get next whitespaces
+        getWhitespaces = function () {
+            var as,
+                chr,
+                ret = "";
+            for (i++; i < length; i++) {
+                chr = source.charAt(i);
+                as = chr.charCodeAt(0);
+                if (isWhitespace(as)) {
+                    ret += chr;
+                } else {
+                    i--;
+                    break;
+                }
+            }
+            return ret;
+        },
+        //Get next word
+        getWord = function (i) {
+            var match = /^[a-zA-Z_]\w*/.exec(source.substr(i));
+            return match ? match[0] : null;
+        },
+        //Get next heredoc declaration
+        getHeredocWord = function () {
+            return (/^<<< *(['"]?[a-zA-Z]\w*)['"]?\r?\n/).exec(source.substr(i));
+        },
+        //Get next type casting declaration
+        getTypeCasting = function () {
+            var match = (/^\( *([a-zA-Z]+) *\)/).exec(source.substr(i));
+            return match && match[1] && (match[1].toLowerCase()) in typeCasting ? match : null;
+        },
+        //Get next php long open declaration
+        getLongOpenDeclaration = function (i) {
+            return (/^php(?:\r?\s)?/i).exec(source.substr(i));
+        },
+        //Get next integer or float number
+        getNumber = function () {
+            var rnum = /^(?:((?:\d+(?:\.\d*)?|\d*\.\d+)[eE][\+\-]?\d+|\d*\.\d+|\d+\.\d*)|(\d+(?:x[0-9a-fA-F]+)?))/,
+                match = rnum.exec(source.substr(i));
+            if (!match) {
+                return null;
+            }
+            if (match[2]) {
+                var isHex = match[2].toLowerCase().indexOf("x") > -1;
+                //If it's greater than 2147483648 it's considered as a floating point number
+                if (parseInt(isHex ? parseInt(match[2], 16) : match[2], 10) < 2147483648) {
+                    return [match[2], tokens.T_LNUMBER];
+                }
+                return [match[2], tokens.T_DNUMBER];
+            }
+            return [match[1], tokens.T_DNUMBER];
+        };
+
+    // Avoid running a conditional for each token by overwriting function
+    if (this.php_js && this.php_js.phpParser) {
+        var oldEmitToken = emitToken;
+        emitToken = function (token, code, preventBuffer, l) {
+            var action = that.php_js.phpParser[typeof token === 'number' ? that.token_name(token) : token];
+            // Allow execution of (optional) parsing callbacks during first run-through
+            if (typeof action === 'function') {
+                action.call(that.php_js.phpParser, code, line, token, preventBuffer, l);
+            }
+            oldEmitToken(token, code, preventBuffer, l);
+        };
+    }
+
+	for (; i < length; i++) {
+		ch = source.charAt(i);
+		ASCII = ch.charCodeAt(0);
+		//Whitespaces
+		if (isWhitespace(ASCII)) {
+			//Get next whitespaces too
+			ch += getWhitespaces();
+			emitToken(ch, tokens.T_WHITESPACE);
+			line += countNewLines(ch);
+		} else if (ch === "#" || (ch === "/" && ((nextch = source.charAt(i + 1)) === "*" || nextch === "/"))) {
+			//Comment signs
+			//Change the buffer only if there's no active buffer
+			if (!bufferType) {
+				if (ch === "#") {
+					getBufferAndEmit("#", "inlineComment", "\n");
+				} else if (ch + nextch === "//") {
+					getBufferAndEmit("//", "inlineComment", "\n");
+				} else if ((ch + nextch + source.charAt(i + 2)) === "/**") {
+					getBufferAndEmit(
+						"/**",
+						//It's a doc comment only if it's followed by a whitespaces
+						isWhitespace(source.charCodeAt(i + 3)) ? "docComment" : "comment",
+						"*/"
+					);
+				} else {
+					getBufferAndEmit("/*", "comment", "*/");
+				}
+				continue;
+			}
+			emitToken(ch);
+		} else if (ch === "$" && (word = getWord(i + 1))) {
+			//Variable
+			if ((bufferType === "heredoc" || bufferType === "doubleQuotes") && !isEscaped()) {
+				splitString();
+				emitToken(ch + word, tokens.T_VARIABLE, true);
+			} else {
+				emitToken(ch + word, tokens.T_VARIABLE);
+			}
+			i += word.length;
+		} else if (ch === "<" && source.substr(i + 1, 2) === "<<" && (word = getHeredocWord())) {
+			//Heredoc and nowdoc start declaration
+			emitToken(word[0], tokens.T_START_HEREDOC);
+			line++;
+			if (!bufferType) {
+				heredocWord = word[1];
+				//If the first character is a quote then it's a nowdoc otherwise it's an heredoc
+				if (heredocWord.charAt(0) === "'") {
+					//Strip the leading quote
+					heredocWord = heredocWord.substr(1);
+					bufferType = "nowdoc";
+				} else {
+					if (heredocWord.charAt(0) === '"') {
+						heredocWord = heredocWord.substr(1);
+					}
+					bufferType = "heredoc";
+				}
+				lineBuffer = line;
+			}
+			i += word[0].length - 1;
+		} else if (ch === "(" && (word = getTypeCasting())) {
+			//Type-casting
+			emitToken(word[0], typeCasting[word[1].toLowerCase()]);
+			i += word[0].length - 1;
+		} else if ((ch === "." || (ch >= "0" && ch <= "9")) && (num = getNumber())) {
+			//Numbers
+			//Numeric array index inside a heredoc or a double quoted string
+			if (lastToken === "[" && (bufferType === "heredoc" || bufferType === "doubleQuotes")) {
+				emitToken(num[0], tokens.T_NUM_STRING, true);
+			} else {
+				emitToken(num[0], num[1]);
+			}
+			i += String(num[0]).length - 1;
+		} else if (singleTokenChars.indexOf(ch) > -1) {
+			//Symbols
+			sym = source.substr(i, 3);
+			if (sym in symbols3chars) {
+				i += 2;
+				//If it's a php open tag emit the html buffer
+				if (bufferType === "html" && symbols3chars[sym] === tokens.T_OPEN_TAG_WITH_ECHO) {
+					emitBuffer();
+				}
+				emitToken(sym, symbols3chars[sym]);
+				continue;
+			}
+			sym = ch + source.charAt(i + 1);
+			if (sym in symbols2chars) {
+				//If it's a php open tag check if it's written in the long form and emit the html buffer
+				if (symbols2chars[sym] === tokens.T_OPEN_TAG && bufferType === "html") {
+					emitBuffer();
+					i++;
+					if (word = getLongOpenDeclaration(i + 1)) {
+						i += word[0].length;
+						sym += word[0];
+					}
+					emitToken(sym, tokens.T_OPEN_TAG);
+					if (sym.indexOf("\n") > -1) {
+						line++;
+					}
+					continue;
+				}
+				i++;
+				//Syntax $obj->prop inside strings and heredoc
+				if (sym === "->" && lastToken === tokens.T_VARIABLE && (bufferType === "heredoc" ||
+					bufferType === "doubleQuotes")) {
+					emitToken(sym, symbols2chars[sym], true);
+					continue;
+				}
+				emitToken(sym, symbols2chars[sym]);
+				//If the token is a PHP close tag and there isn't an active buffer start an html buffer
+				if (!bufferType && symbols2chars[sym] === tokens.T_CLOSE_TAG) {
+					//PHP closing tag includes the following new line characters
+					if (nextch = /^\r?\n/.exec(source.substr(i + 1, 2))) {
+						ret[ret.length - 1][1] += nextch[0];
+						i += nextch[0].length;
+						line++;
+					}
+					bufferType = "html";
+					lineBuffer = line;
+				}
+				continue;
+			}
+			//Start string buffers if there isn't an active buffer and the character is a quote
+			if (!bufferType && (ch === "'" || ch === '"')) {
+				if (ch === "'") {
+					getBufferAndEmit("'", "singleQuote", "'", true);
+				} else {
+					split = false;
+					bufferType = "doubleQuotes";
+					lineBuffer = line;
+					//Add the token to the buffer and continue to skip next checks
+					emitToken(ch);
+				}
+				continue;
+			} else if (ch === '"' && bufferType === "doubleQuotes" && !isEscaped()) {
+				//If the string has been splitted emit the current buffer and the double quotes
+				//as separate tokens
+				if (split) {
+					splitString();
+					bufferType = null;
+					emitToken('"');
+				} else {
+					emitToken('"');
+					emitBuffer();
+				}
+				continue;
+			} else if (bufferType === "heredoc" || bufferType === "doubleQuotes") {
+				//Array index delimiters inside heredoc or double quotes
+				if ((ch === "[" && lastToken === tokens.T_VARIABLE) ||
+                        (ch === "]" && (lastToken === tokens.T_NUM_STRING ||
+                        lastToken === tokens.T_STRING))) {
+					emitToken(ch, null, true);
+					continue;
+				} else if (((ch === "$" && source.charAt(i + 1) === "{") ||
+							(ch === "{" && source.charAt(i + 1) === "$")) &&
+							!isEscaped()) {
+					//Complex variable syntax ${varname} or {$varname}. Store the current
+					//buffer type and evaluate next tokens as there's no active buffer.
+					//The current buffer will be reset when the declaration is closed
+					splitString();
+					complexVarPrevBuffer = bufferType;
+					bufferType = null;
+					if (ch === "$") {
+						emitToken(ch + "{", tokens.T_DOLLAR_OPEN_CURLY_BRACES);
+						i++;
+					} else {
+						emitToken(ch, tokens.T_CURLY_OPEN);
+					}
+					openBrackets = 1;
+					continue;
+				}
+			} else if (ch === "\\") {
+				//Namespace separator
+				emitToken(ch, tokens.T_NS_SEPARATOR);
+				continue;
+			}
+			emitToken(ch);
+			//Increment or decrement the number of open brackets inside a complex
+			//variable syntax
+			if (complexVarPrevBuffer && (ch === "{" || ch === "}")) {
+				if (ch === "{") {
+					openBrackets++;
+				} else if (!--openBrackets) {
+					//If every bracket has been closed reset the previous buffer
+					bufferType = complexVarPrevBuffer;
+					complexVarPrevBuffer = null;
+				}
+			}
+		} else if (word = getWord(i)) {
+			//Words
+			var wordLower = word.toLowerCase();
+			//Check to see if it's a keyword
+			if (keywordsToken.hasOwnProperty(word) || keywordsToken.hasOwnProperty(wordLower)) {
+				//If it's preceded by -> than it's an object property and it must be tokenized as T_STRING
+				emitToken(
+					word,
+					lastToken === tokens.T_OBJECT_OPERATOR ?
+                        tokens.T_STRING :
+                        keywordsToken[word] || keywordsToken[wordLower]
+				);
+				i += word.length - 1;
+				continue;
+			}
+			//Stop the heredoc or the nowdoc if it's the word that has generated it
+			if ((bufferType === "nowdoc" || bufferType === "heredoc") && word === heredocWord &&
+                    source.charAt(i - 1) === "\n" &&
+                    heredocEndFollowing.test(source.substr(i + word.length))) {
+				emitBuffer();
+				emitToken(word, tokens.T_END_HEREDOC);
+				i += word.length - 1;
+				continue;
+			} else if ((bufferType === "heredoc" || bufferType === "doubleQuotes")) {
+				if (lastToken === "[") {
+					//Literal array index inside a heredoc or a double quoted string
+					emitToken(word, tokens.T_STRING, true);
+					i += word.length - 1;
+					continue;
+				} else if (lastToken === tokens.T_OBJECT_OPERATOR) {
+					//Syntax $obj->prop inside strings and heredoc
+					emitToken(word, tokens.T_STRING, true);
+					i += word.length - 1;
+					continue;
+				}
+			} else if (complexVarPrevBuffer && lastToken === tokens.T_DOLLAR_OPEN_CURLY_BRACES) {
+				//Complex variable syntax  ${varname}
+				emitToken(word, tokens.T_STRING_VARNAME);
+				i += word.length - 1;
+				continue;
+			}
+			emitToken(word, tokens.T_STRING);
+			i += word.length - 1;
+		} else if (ASCII < 32) {
+			//If below ASCII 32 it's a bad character
+			emitToken(ch, tokens.T_BAD_CHARACTER);
+		} else {
+			//If there isn't an open buffer there should be an syntax error, but we don't care
+			//so it will be emitted as a simple string
+			emitToken(ch, tokens.T_STRING);
+		}
+	}
+	//If there's an open buffer emit it
+	if (bufferType && (bufferType !== "doubleQuotes" || !split)) {
+		emitBuffer();
+	} else {
+		splitString();
+	}
+	return ret;
+};
+};

--- a/test/check-textdomain_test.js
+++ b/test/check-textdomain_test.js
@@ -1,0 +1,107 @@
+/*jshint node:true */
+'use strict';
+
+var grunt = require('grunt');
+
+/*
+  ======== A Handy Little Nodeunit Reference ========
+  https://github.com/caolan/nodeunit
+
+  Test methods:
+    test.expect(numAssertions)
+    test.done()
+  Test assertions:
+    test.ok(value, [message])
+    test.equal(actual, expected, [message])
+    test.notEqual(actual, expected, [message])
+    test.deepEqual(actual, expected, [message])
+    test.notDeepEqual(actual, expected, [message])
+    test.strictEqual(actual, expected, [message])
+    test.notStrictEqual(actual, expected, [message])
+    test.throws(block, [error], [message])
+    test.doesNotThrow(block, [error], [message])
+    test.ifError(value)
+*/
+
+exports.textdomain = {
+  setUp: function(done) {
+    // setup here if necessary
+    done();
+  },
+  
+  incorrect_domain_autocorrect: function(test) {
+      test.expect(2);
+      
+      // There are 14 missing domains
+      var actual = JSON.parse( grunt.file.read( 'tmp/check-textdomain/incorrect-domain-autocomplete.json' ) );
+      test.equal( actual['tmp/check-textdomain/incorrect-domain-autocorrect.php'].length, 14, '14 errors to report' );
+      
+      // Test corrected file
+      var corrected = grunt.file.read( 'tmp/check-textdomain/incorrect-domain-autocorrect.php' );
+      var expected = grunt.file.read( 'test/expected/incorrect-domain-autocorrect.php' );
+      test.equal( corrected, expected, 'Domain should have been corrected' );
+      
+      test.done();
+      
+  },
+  
+  variable_domain_autocorrect: function(test) {
+      test.expect(2);
+      
+      // There are 14 missing domains
+      var actual = JSON.parse( grunt.file.read( 'tmp/check-textdomain/variable-domain-autocorrect.json' ) );
+      test.equal( actual['tmp/check-textdomain/variable-domain-autocorrect.php'].length, 14, '14 errors to report' );
+      
+      // Test corrected file
+      var corrected = grunt.file.read( 'tmp/check-textdomain/variable-domain-autocorrect.php' );
+      var expected = grunt.file.read( 'test/expected/variable-domain-autocorrect.php' );
+      test.equal( corrected, expected, 'Domain should have been corrected' );
+      
+      test.done();
+  },
+  
+  missing_domain: function(test) {  
+      test.expect(1);
+      
+      // There are 14 missing domains
+      var actual = JSON.parse( grunt.file.read( 'tmp/check-textdomain/missing-domain.json' ) );
+      test.equal( actual['tmp/check-textdomain/missing-domain.php'].length, 14, '14 errors to report' );
+      
+      test.done();
+  },
+  
+  missing_domain_ignore_missing: function(test) {  
+      test.expect(1);
+      
+      var actual = JSON.parse( grunt.file.read( 'tmp/check-textdomain/missing-domain-ignore-missing.json' ) );
+      
+      //File only has missing domain, which we are nor reporting. There should be no errors.
+      test.equal( actual['tmp/check-textdomain/missing-domain.php'].length, 0, 'No errors reported' );
+      
+      test.done();
+  },
+  
+  correct_domain: function(test) {  
+      test.expect(1);
+      
+      var actual = JSON.parse( grunt.file.read( 'tmp/check-textdomain/correct-domain.json' ) );
+      
+      //File is correct, should report no errors
+      test.equal( actual['tmp/check-textdomain/correct-domain.php'].length, 0, 'No errors reported' );
+      
+      test.done();
+  },
+  
+  
+  plurals: function(test) {  
+      test.expect(1);
+      
+      var actual = JSON.parse( grunt.file.read( 'tmp/check-textdomain/plurals.json' ) );
+      
+      //File is correct, should report no errors
+      test.equal( actual['tmp/check-textdomain/plurals.php'].length, 0, 'No errors reported' );
+      
+      test.done();
+  },
+  
+};

--- a/test/expected/incorrect-domain-autocorrect.php
+++ b/test/expected/incorrect-domain-autocorrect.php
@@ -1,0 +1,26 @@
+<?php
+
+__( 'Hello World', 'my-domain' );
+_x( 'Post', 'verb', 'my-domain' );
+_e( 'Hello World', 'my-domain' );
+_ex( 'Post', 'verb', 'my-domain' );
+
+
+esc_html__( 'Hello World', 'my-domain' );
+esc_html_e( 'Hello World', 'my-domain' );
+esc_html_x( 'Post', 'verb', 'my-domain' );
+
+
+esc_attr__( 'Hello World', 'my-domain' );
+esc_attr_e( 'Hello World', 'my-domain' );
+esc_attr_x( 'Post', 'verb', 'my-domain' );
+
+
+$apples = 4;
+_n( '%d apple', '%d apples', $apples, 'my-domain' );
+_nx( '%d post', '%d posts', $apples, 'noun, job positions', 'my-domain' );
+
+
+_n_noop( '%d apple', '%d apples', 'my-domain' );
+_nx_noop( '%d post', '%d posts', 'noun, job positions', 'my-domain' );
+?>

--- a/test/expected/variable-domain-autocorrect.php
+++ b/test/expected/variable-domain-autocorrect.php
@@ -1,0 +1,27 @@
+<?php
+$domain = 'my-domain'; //Allthough correct, this should fail.
+
+__( 'Hello World', 'my-domain' );
+_x( 'Post', 'verb', 'my-domain' );
+_e( 'Hello World', 'my-domain' );
+_ex( 'Post', 'verb', 'my-domain' );
+
+
+esc_html__( 'Hello World', 'my-domain' );
+esc_html_e( 'Hello World', 'my-domain' );
+esc_html_x( 'Post', 'verb', 'my-domain' );
+
+
+esc_attr__( 'Hello World', 'my-domain' );
+esc_attr_e( 'Hello World', 'my-domain' );
+esc_attr_x( 'Post', 'verb', 'my-domain' );
+
+
+$apples = 4;
+_n( '%d apple', '%d apples', $apples, 'my-domain' );
+_nx( '%d post', '%d posts', $apples, 'noun, job positions', 'my-domain' );
+
+
+_n_noop( '%d apple', '%d apples', 'my-domain' );
+_nx_noop( '%d post', '%d posts', 'noun, job positions', 'my-domain' );
+?>

--- a/test/fixtures/check-textdomain/correct-domain.php
+++ b/test/fixtures/check-textdomain/correct-domain.php
@@ -1,0 +1,26 @@
+<?php
+
+__( 'Hello World', 'my-domain' );
+_x( 'Post', 'verb', 'my-domain' );
+_e( 'Hello World', 'my-domain' );
+_ex( 'Post', 'verb', 'my-domain' );
+
+
+esc_html__( 'Hello World', 'my-domain' );
+esc_html_e( 'Hello World', 'my-domain' );
+esc_html_x( 'Post', 'verb', 'my-domain' );
+
+
+esc_attr__( 'Hello World', 'my-domain' );
+esc_attr_e( 'Hello World', 'my-domain' );
+esc_attr_x( 'Post', 'verb', 'my-domain' );
+
+
+$apples = 4;
+_n( '%d apple', '%d apples', $apples, 'my-domain' );
+_nx( '%d post', '%d posts', $apples, 'noun, job positions', 'my-domain' );
+
+
+_n_noop( '%d apple', '%d apples', 'my-domain' );
+_nx_noop( '%d post', '%d posts', 'noun, job positions', 'my-domain' );
+?>

--- a/test/fixtures/check-textdomain/incorrect-domain-autocorrect.php
+++ b/test/fixtures/check-textdomain/incorrect-domain-autocorrect.php
@@ -1,0 +1,26 @@
+<?php
+
+__( 'Hello World', 'incorrect-domain' );
+_x( 'Post', 'verb', 'incorrect-domain' );
+_e( 'Hello World', 'incorrect-domain' );
+_ex( 'Post', 'verb', 'incorrect-domain' );
+
+
+esc_html__( 'Hello World', 'incorrect-domain' );
+esc_html_e( 'Hello World', 'incorrect-domain' );
+esc_html_x( 'Post', 'verb', 'incorrect-domain' );
+
+
+esc_attr__( 'Hello World', 'incorrect-domain' );
+esc_attr_e( 'Hello World', 'incorrect-domain' );
+esc_attr_x( 'Post', 'verb', 'incorrect-domain' );
+
+
+$apples = 4;
+_n( '%d apple', '%d apples', $apples, 'incorrect-domain' );
+_nx( '%d post', '%d posts', $apples, 'noun, job positions', 'incorrect-domain' );
+
+
+_n_noop( '%d apple', '%d apples', 'incorrect-domain' );
+_nx_noop( '%d post', '%d posts', 'noun, job positions', 'incorrect-domain' );
+?>

--- a/test/fixtures/check-textdomain/incorrect-domain.php
+++ b/test/fixtures/check-textdomain/incorrect-domain.php
@@ -1,0 +1,26 @@
+<?php
+
+__( 'Hello World', 'incorrect-domain' );
+_x( 'Post', 'verb', 'incorrect-domain' );
+_e( 'Hello World', 'incorrect-domain' );
+_ex( 'Post', 'verb', 'incorrect-domain' );
+
+
+esc_html__( 'Hello World', 'incorrect-domain' );
+esc_html_e( 'Hello World', 'incorrect-domain' );
+esc_html_x( 'Post', 'verb', 'incorrect-domain' );
+
+
+esc_attr__( 'Hello World', 'incorrect-domain' );
+esc_attr_e( 'Hello World', 'incorrect-domain' );
+esc_attr_x( 'Post', 'verb', 'incorrect-domain' );
+
+
+$apples = 4;
+_n( '%d apple', '%d apples', $apples, 'incorrect-domain' );
+_nx( '%d post', '%d posts', $apples, 'noun, job positions', 'incorrect-domain' );
+
+
+_n_noop( '%d apple', '%d apples', 'incorrect-domain' );
+_nx_noop( '%d post', '%d posts', 'noun, job positions', 'incorrect-domain' );
+?>

--- a/test/fixtures/check-textdomain/missing-domain.php
+++ b/test/fixtures/check-textdomain/missing-domain.php
@@ -1,0 +1,26 @@
+<?php
+
+__( 'Hello World' );
+_x( 'Post', 'verb' );
+_e( 'Hello World' );
+_ex( 'Post', 'verb' );
+
+
+esc_html__( 'Hello World' );
+esc_html_e( 'Hello World' );
+esc_html_x( 'Post', 'verb' );
+
+
+esc_attr__( 'Hello World' );
+esc_attr_e( 'Hello World' );
+esc_attr_x( 'Post', 'verb' );
+
+
+$apples = 4;
+_n( '%d apple', '%d apples', $apples );
+_nx( '%d post', '%d posts', $apples );
+
+
+_n_noop( '%d apple', '%d apples' );
+_nx_noop( '%d post', '%d posts', 'noun, job positions' );
+?>

--- a/test/fixtures/check-textdomain/plurals.php
+++ b/test/fixtures/check-textdomain/plurals.php
@@ -1,0 +1,19 @@
+<?php
+
+_n( '%d apple', '%d apples', 4, 'my-domain' );
+_nx( '%d post', '%d posts', 4, 'noun, job positions', 'my-domain' );
+
+//Using a variable
+$apples = 4;
+_n( '%d apple', '%d apples', $apples, 'my-domain' );
+_nx( '%d post', '%d posts', $apples, 'noun, job positions', 'my-domain' );
+
+//Using a function
+function __return( $int ){
+	return $int;
+}
+_n( '%d apple', '%d apples', __return( 4 ), 'my-domain' );
+_nx( '%d post', '%d posts', __return( 4 ), 'noun, job positions', 'my-domain' );
+
+
+?>

--- a/test/fixtures/check-textdomain/variable-domain-autocorrect.php
+++ b/test/fixtures/check-textdomain/variable-domain-autocorrect.php
@@ -1,0 +1,27 @@
+<?php
+$domain = 'my-domain'; //Allthough correct, this should fail.
+
+__( 'Hello World', $domain );
+_x( 'Post', 'verb', $domain );
+_e( 'Hello World', $domain );
+_ex( 'Post', 'verb', $domain );
+
+
+esc_html__( 'Hello World', $domain );
+esc_html_e( 'Hello World', $domain );
+esc_html_x( 'Post', 'verb', $domain );
+
+
+esc_attr__( 'Hello World', $domain );
+esc_attr_e( 'Hello World', $domain );
+esc_attr_x( 'Post', 'verb', $domain );
+
+
+$apples = 4;
+_n( '%d apple', '%d apples', $apples, $domain );
+_nx( '%d post', '%d posts', $apples, 'noun, job positions', $domain );
+
+
+_n_noop( '%d apple', '%d apples', $domain );
+_nx_noop( '%d post', '%d posts', 'noun, job positions', $domain );
+?>


### PR DESCRIPTION
This is a first pass.

This is a fork from  https://github.com/stephenharris/grunt-checktextdomain and the majority of the commit is from code Stephen Harris wrote.

This commit:
- Changes option names to be camel case instead of underscores, as per common practice. Fixes https://github.com/stephenharris/grunt-checktextdomain/issues/2
- Allows `createReportFile` to accept a file path string instead of just being a boolean. This is used within the unit tests to keep the generated report files within the `tmp/` directory. This directory is already cleaned before testing, so it avoids having to tidy up each file during the testing as it was in the original code.
- Passes all existing unit tests. No functional testing done yet.
- Tweaks and merges existing documentation into `README.md`.

More work will be needed on making the options more compatible between this and the existing tasks, and that functionality doesn't overlap, but this should be a good start.
