### PR TITLE
Fix keywords list common header default value

### DIFF
--- a/tasks/lib/util.js
+++ b/tasks/lib/util.js
@@ -111,7 +111,7 @@ exports.init = function( grunt ) {
 
 		// Add the the Poedit keywordslist header.
 		if ( 'x-poedit-keywordslist' in headers && true === headers['x-poedit-keywordslist'] ) {
-			pot.headers['x-poedit-keywordslist'] = '__;_e;__ngettext:1,2;_n:1,2;__ngettext_noop:1,2;_n_noop:1,2;_c;_nc:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;_nx_noop:4c,1,2;';
+			pot.headers['x-poedit-keywordslist'] = '__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;';
 			delete headers['x-poedit-keywordslist'];
 		}
 


### PR DESCRIPTION
I spent considerable time looking into what this deciphers as, and most themes and plugins have it wrong. The string that this commit replaces included deprecated functions that no-one should be using, and didn't include the escaping functions. That means Poedit would not be picking up on strings wrapped in valid i18n functions.

This new string can be confirmed with the data at https://github.com/stephenharris/grunt-checktextdomain/blob/6e98c54be3058e4c510a7c0e564457485df34006/Gruntfile.js#L13 though that includes the custom `d` flag, that is something unique to `grunt-checktextdomain`.
