### PR TITLE
Exclude bower_components directory by default :)

### DIFF
--- a/tasks/makepot.js
+++ b/tasks/makepot.js
@@ -86,8 +86,8 @@ module.exports = function( grunt ) {
 		// Reset the working directory.
 		grunt.file.setBase( gruntBase );
 
-		// Exclude the node_modules directory by default.
-		o.exclude.push( 'node_modules/.*' );
+		// Exclude the node_modules & bower_components directory by default.
+		o.exclude.push( 'node_modules/.*', 'bower_components/.*' );
 
 		// Build the list of CLI args.
 		cmdArgs = [


### PR DESCRIPTION
If the people are using bower too they they may forgot to exclude `bower_components` so it's better to add this by default.
