### PR TITLE
Changed class constructors to the __construct syntax.

### DIFF
--- a/vendor/wp-i18n-tools/add-textdomain.php
+++ b/vendor/wp-i18n-tools/add-textdomain.php
@@ -13,7 +13,7 @@ class AddTextdomain {
 	public $modified_contents = '';
 	public $funcs;
 
-	public function AddTextdomain() {
+	public function __construct() {
 		$makepot = new MakePOT;
 		$this->funcs = array_keys( $makepot->rules );
 	}

--- a/vendor/wp-i18n-tools/pomo/entry.php
+++ b/vendor/wp-i18n-tools/pomo/entry.php
@@ -40,7 +40,7 @@ class Translation_Entry {
 	 * 	- references (array) -- places in the code this strings is used, in relative_to_root_path/file.php:linenum form
 	 * 	- flags (array) -- flags like php-format
 	 */
-	public function Translation_Entry( $args=array() ) {
+	public function __construct( $args=array() ) {
 		// if no singular -- empty object
 		if ( !isset( $args['singular'] ) ) {
 			return;

--- a/vendor/wp-i18n-tools/pomo/streams.php
+++ b/vendor/wp-i18n-tools/pomo/streams.php
@@ -14,7 +14,7 @@ class POMO_Reader {
 	var $endian = 'little';
 	var $_post = '';
 
-	function POMO_Reader() {
+	function __construct() {
 		$this->is_overloaded = ((ini_get("mbstring.func_overload") & 2) != 0) && function_exists('mb_substr');
 		$this->_pos = 0;
 	}
@@ -104,8 +104,8 @@ endif;
 
 if ( !class_exists( 'POMO_FileReader' ) ):
 class POMO_FileReader extends POMO_Reader {
-	function POMO_FileReader ($filename ) {
-		parent::POMO_Reader();
+	function __construct ($filename ) {
+		parent::__construct();
 		$this->_f = fopen( $filename, 'rb' );
 	}
 
@@ -151,8 +151,8 @@ class POMO_StringReader extends POMO_Reader {
 
 	var $_str = '';
 
-	public function POMO_StringReader( $str = '' ) {
-		parent::POMO_Reader();
+	public function __construct( $str = '' ) {
+		parent::__construct();
 		$this->_str = $str;
 		$this->_pos = 0;
 	}
@@ -187,8 +187,8 @@ if ( !class_exists( 'POMO_CachedFileReader' ) ):
  * Reads the contents of the file in the beginning.
  */
 class POMO_CachedFileReader extends POMO_StringReader {
-	public function POMO_CachedFileReader( $filename ) {
-		parent::POMO_StringReader();
+	public function __construct( $filename ) {
+		parent::__construct();
 		$this->_str = file_get_contents( $filename );
 		if ( false === $this->_str )
 			return false;
@@ -202,8 +202,8 @@ if ( !class_exists( 'POMO_CachedIntFileReader' ) ):
  * Reads the contents of the file in the beginning.
  */
 class POMO_CachedIntFileReader extends POMO_CachedFileReader {
-	public function POMO_CachedIntFileReader( $filename ) {
-		parent::POMO_CachedFileReader( $filename );
+	public function __construct( $filename ) {
+		parent::__construct( $filename );
 	}
 }
 endif;


### PR DESCRIPTION
Just a warning today, might be an issue in the future, as per a PHP warning message, methods with the same name as their class will not be constructors in a future version of PHP.

Please have a look at the proposed changes.

Thank you!