### PR TITLE
Bump grunt to ~1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   "dependencies": {
     "async": "~0.9.0",
     "gettext-parser": "~1.1.0",
-    "grunt": "~0.4.5",
+    "grunt": "~1.0.1",
     "underscore": "~1.8.2",
     "underscore.string": "~3.0.3"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": "~1.0.1",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-copy": "~0.8.0",
     "grunt-contrib-jshint": "~0.11.1",

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "~0.9.0",
-    "gettext-parser": "~1.1.0",
+    "async": "~2.1.4",
+    "gettext-parser": "~1.2.2",
     "grunt": "~1.0.1",
     "underscore": "~1.8.2",
-    "underscore.string": "~3.0.3"
+    "underscore.string": "~3.3.4"
   },
   "devDependencies": {
     "grunt": "~1.0.1",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-copy": "~0.8.0",
-    "grunt-contrib-jshint": "~0.11.1",
-    "grunt-contrib-nodeunit": "~0.4.1"
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-copy": "~1.0.0",
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-contrib-nodeunit": "~1.0.0"
   },
   "peerDependencies": {
     "grunt": "~1.0.1"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-nodeunit": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": "~1.0.1"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
I recently noticed that a fair amount of my install warning nags could be traced back to this, so I was wondering if it would be possible to bump this up?

I tested a bit on my local and nothing seemed to break, but I don't know how much that really means...

Might also be worth bumping these, but I didn't want any incompatibilities in them to prevent this from being merged:

```
 async                    ~0.9.0  →  ~2.1.4
 gettext-parser           ~1.1.0  →  ~1.2.2
 underscore.string        ~3.0.3  →  ~3.3.4
 grunt-contrib-clean      ~0.6.0  →  ~1.0.0
 grunt-contrib-copy       ~0.8.0  →  ~1.0.0
 grunt-contrib-jshint    ~0.11.1  →  ~1.1.0
 grunt-contrib-nodeunit   ~0.4.1  →  ~1.0.0
 underscore               ~1.8.2  →  ~1.8.3
```